### PR TITLE
Fixed release workflow

### DIFF
--- a/.github/workflows/release-plugins.yaml
+++ b/.github/workflows/release-plugins.yaml
@@ -12,6 +12,9 @@ on:
     paths:
       - 'backstage/plugins/knative-event-mesh-backend/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   release:
     name: Release
@@ -26,17 +29,24 @@ jobs:
         with:
           go-version: '>=1.21.1' # from https://github.com/openshift-knative/hack/blob/main/go.mod#L3
 
+      - name: Checkout openshift-knative/hack
+        uses: actions/checkout@v4
+        with:
+          repository: 'openshift-knative/hack'
+          ref: 'main'
+          path: ./src/github.com/openshift-knative/hack
+
+      - name: Install sobranch
+        run: |
+          go install ./cmd/sobranch
+        working-directory: ./src/github.com/openshift-knative/hack
+
       - name: Setup release name for release branch push
         if: github.event_name == 'push'
         run: |
           BRANCH=$(git rev-parse --abbrev-ref HEAD) #e.g. release-v1.33
           echo "Release branch: ${BRANCH}"
           
-          cd /tmp
-          git clone https://github.com/openshift-knative/hack.git
-          cd hack
-          go install ./cmd/sobranch
-          cd -
           SO_RELEASE_NAME=$( $(go env GOPATH)/bin/sobranch --upstream-version "${BRANCH}") # input format: "release-v1.11" or "release-1.11" or "v1.11" or "1.11"
           # SO_RELEASE_NAME will be something like "release-1.33"
           echo "SO_RELEASE_NAME: ${SO_RELEASE_NAME}"

--- a/.github/workflows/release-plugins.yaml
+++ b/.github/workflows/release-plugins.yaml
@@ -16,9 +16,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write # allow GITHUB_TOKEN to publish packages
 
     steps:
       - name: Checkout
@@ -34,10 +31,16 @@ jobs:
         run: |
           BRANCH=$(git rev-parse --abbrev-ref HEAD) #e.g. release-v1.33
           echo "Release branch: ${BRANCH}"
-          GO111MODULE=off go get -u github.com/openshift-knative/hack/cmd/sobranch
+          
+          cd /tmp
+          git clone https://github.com/openshift-knative/hack.git
+          cd hack
+          go install ./cmd/sobranch
+          cd -
           SO_RELEASE_NAME=$( $(go env GOPATH)/bin/sobranch --upstream-version "${BRANCH}") # input format: "release-v1.11" or "release-1.11" or "v1.11" or "1.11"
           # SO_RELEASE_NAME will be something like "release-1.33"
           echo "SO_RELEASE_NAME: ${SO_RELEASE_NAME}"
+          
           # split the release name to get the version number
           ## e.g. release-1.33 -> 1.33
           BASE_RELEASE_VERSION=${SO_RELEASE_NAME#*-}
@@ -45,16 +48,24 @@ jobs:
           
           RELEASE_NAME="${BASE_RELEASE_VERSION}.0"
           
-          # get the patch release versions for the BASE_RELEASE_VERSION
-          # if there's one already, increase its number by 1
-          PATCH_RELEASES=$(npm view @openshift-knative/plugin-knative-event-mesh-backend versions --json | grep ${BASE_RELEASE_VERSION})
-          echo "Existing PATCH_RELEASES: ${PATCH_RELEASES}"
-          if [ -z "${PATCH_RELEASES}" ]; then
-            echo "No existing PATCH_RELEASES found for ${BASE_RELEASE_VERSION}"
+          EXISTING_RELEASES=""
+          
+          if EXISTING_RELEASES=$(npm view @openshift-knative/plugin-knative-event-mesh-backend versions --json); then
+            echo "Package information fetched successfully"
+            echo "Existing releases: ${EXISTING_RELEASES}"
+            PATCH_RELEASES=$(echo "${EXISTING_RELEASES}" | grep ${BASE_RELEASE_VERSION})
+            if [ -z "${PATCH_RELEASES}" ]; then
+              echo "No existing PATCH_RELEASES found for ${BASE_RELEASE_VERSION}"
+              echo "Going to publish a new .0 patch release"
+              RELEASE_NAME="${BASE_RELEASE_VERSION}.0"
+            else
+              echo "Existing PATCH_RELEASES found for ${BASE_RELEASE_VERSION}"
+              PATCH=$(echo "${PATCH_RELEASES}" | tail -1 | tr -d '"' | awk -F \. '{print $3+1}')
+              RELEASE_NAME="${BASE_RELEASE_VERSION}.${PATCH}"
+            fi
           else
-            echo "Existing PATCH_RELEASES found for ${BASE_RELEASE_VERSION}"
-            PATCH=$(echo "${PATCH_RELEASES}" | tail -1 | tr -d '"' | awk -F \. '{print $3+1}')
-            RELEASE_NAME="${BASE_RELEASE_VERSION}.${PATCH}"
+            echo "Error fetching package information. Going to publish a new .0 patch release"
+            RELEASE_NAME="${BASE_RELEASE_VERSION}.0"
           fi
           
           echo "RELEASE_NAME: ${RELEASE_NAME}"
@@ -116,10 +127,9 @@ jobs:
         uses: JS-DevTools/npm-publish@v3
         if: github.event_name == 'push'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NPM_TOKEN }}
           access: public
           package: backstage/plugins/knative-event-mesh-backend
-          registry: "https://npm.pkg.github.com"
           tag: latest
 
       - name: Postpack knative-event-mesh-backend plugin


### PR DESCRIPTION
Tested in a fork: https://github.com/aliok/backstage-plugins-no-fork-test/actions/runs/9019191002/job/24781526167

Changes:
- Switch to using regular NPM registry, so that installation is simple (npm install ...)
- Clone the `sobranch` tool repo as `go install` or `go get` doesn't work
- Increment the patch version by checking existing versions