### PR TITLE
[main] Use openshift-4.17 variant for Golang builder

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -10,4 +10,4 @@ GOFLAGS='' go install github.com/openshift-knative/hack/cmd/generate@latest
 $(go env GOPATH)/bin/generate \
   --root-dir "${repo_root_dir}" \
   --generators dockerfile \
-  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.16"
+  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17"


### PR DESCRIPTION
Related to https://github.com/openshift-knative/backstage-plugins/pull/110
This is an update for main branch.