### PR TITLE
[release-v1.16] Set golang patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/backstage-plugins
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
Seems catchi2 wants the patch version

```
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
2025-03-06 14:12:25,141 ERROR PackageManagerError: Go execution failed: `go env GOWORK` failed with rc=1
Error: PackageManagerError: Go execution failed: `go env GOWORK` failed with rc=1
  The cause of the failure could be:
  - something is broken in Cachi2
  - something is wrong with your repository
  - communication with an external service failed (please try again)
  The output of the failing command should provide more details, please check the logs.
```