### PR TITLE
Remove image-builder-fmt param from Dockerfile Generator to fallback to default

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -9,5 +9,4 @@ GOFLAGS='' go install github.com/openshift-knative/hack/cmd/generate@latest
 
 $(go env GOPATH)/bin/generate \
   --root-dir "${repo_root_dir}" \
-  --generators dockerfile \
-  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17"
+  --generators dockerfile


### PR DESCRIPTION
As per title. So we don't need to adjust the OCP or RHEL versions in future